### PR TITLE
Fix typo in 'Frotran'

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A curated list of awesome Fortran frameworks, libraries and software. Inspired b
 - [Contributing](#contributing)
 
 ## Functional Libraries
-* [Functional Frotran](https://github.com/wavebitscientific/functional-fortran) - Functional programming for modern Fortran.
+* [Functional Fortran](https://github.com/wavebitscientific/functional-fortran) - Functional programming for modern Fortran.
 
 
 ## Graphics Libraries


### PR DESCRIPTION
Minor edit to correct a typo - change 'Frotran' to 'Fortran'